### PR TITLE
Fix parsing with newer bitbake

### DIFF
--- a/classes/java.bbclass
+++ b/classes/java.bbclass
@@ -5,21 +5,21 @@
 # the Debian distribution.
 
 # Jar location on target
-datadir_java ?= ${datadir}/java
+datadir_java ?= "${datadir}/java"
 
 # JNI library location on target
-libdir_jni ?= ${libdir}/jni
+libdir_jni ?= "${libdir}/jni"
 
 # JVM bundle location on target
-libdir_jvm ?= ${libdir}/jvm
+libdir_jvm ?= "${libdir}/jvm"
 
-STAGING_DATADIR_JAVA ?= ${STAGING_DATADIR}/java
-STAGING_LIBDIR_JNI ?= ${STAGING_LIBDIR}/jni
-STAGING_LIBDIR_JVM ?= ${STAGING_LIBDIR}/jvm
+STAGING_DATADIR_JAVA ?= "${STAGING_DATADIR}/java"
+STAGING_LIBDIR_JNI ?= "${STAGING_LIBDIR}/jni"
+STAGING_LIBDIR_JVM ?= "${STAGING_LIBDIR}/jvm"
 
-STAGING_DATADIR_JAVA_NATIVE ?= ${STAGING_DATADIR_NATIVE}/java
-STAGING_LIBDIR_JNI_NATIVE ?= ${STAGING_LIBDIR_NATIVE}/jni
-STAGING_LIBDIR_JVM_NATIVE ?= ${STAGING_LIBDIR_NATIVE}/jvm
+STAGING_DATADIR_JAVA_NATIVE ?= "${STAGING_DATADIR_NATIVE}/java"
+STAGING_LIBDIR_JNI_NATIVE ?= "${STAGING_LIBDIR_NATIVE}/jni"
+STAGING_LIBDIR_JVM_NATIVE ?= "${STAGING_LIBDIR_NATIVE}/jvm"
 
 oe_jarinstall() {
   # Purpose: Install a jar file and create all the given symlinks to it.

--- a/recipes-core/xml-commons/dom4j_1.6.1.bb
+++ b/recipes-core/xml-commons/dom4j_1.6.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "dom4j is a simple and flexible Java library for working with XML, XPath and XSLT"
 LICENSE = "BSD"
 
-HOMEPAGE = "http://dom4j.org
+HOMEPAGE = "http://dom4j.org"
 
 DEPENDS = "fastjar-native xerces-j xalan-j xpp2 xpp3 jaxen"
 

--- a/recipes-core/xml-commons/jaxen_1.1.1.bb
+++ b/recipes-core/xml-commons/jaxen_1.1.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "XPath library written in Java"
 LICENSE = "BSD"
 
-HOMEPAGE = "http://jaxen.codehaus.org/
+HOMEPAGE = "http://jaxen.codehaus.org/"
 
 DEPENDS = "fastjar-native xerces-j xom"
 

--- a/recipes-core/xml-commons/jdom_1.1.bb
+++ b/recipes-core/xml-commons/jdom_1.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Parses, manipulates, and outputs XML using standard Java constructs"
 LICENSE = "BSD"
 
-HOMEPAGE = "http://jdom.org/
+HOMEPAGE = "http://jdom.org/"
 
 DEPENDS = "fastjar-native jaxen"
 


### PR DESCRIPTION
Bitbake now enforces that all assignments are proper quotted otherwise
it raises an exeption while parsing.

Signed-off-by: Otavio Salvador otavio@ossystems.com.br
