### PR TITLE
Fix for sysroot race condition

### DIFF
--- a/recipes-core/classpath/classpath-initial_0.93.bb
+++ b/recipes-core/classpath/classpath-initial_0.93.bb
@@ -32,6 +32,9 @@ EXTRA_OECONF = " \
                 --with-vm=java \
               "
 
+# Ensure tools.zip is not installed at same path as classpath-native
+EXTRA_OEMAKE += "pkgdatadir=${STAGING_DATADIR_NATIVE}/classpath-initial"
+
 SRC_URI[md5sum] = "ffa9e9cac31c5acbf0ea9eff9efa923d"
 SRC_URI[sha256sum] = "df2d093612abd23fe67e9409d89bb2a8e79b1664fe2b2da40e1c8ed693e32945"
 

--- a/recipes-core/classpath/classpath-native.inc
+++ b/recipes-core/classpath/classpath-native.inc
@@ -4,6 +4,8 @@ LICENSE = "Classpath"
 
 DEPENDS = "ecj-initial fastjar-native zip-native gettext-native"
 
+PR = "r1"
+
 inherit autotools native
 
 SRC_URI = "${GNU_MIRROR}/classpath/classpath-${PV}.tar.gz"

--- a/recipes-core/classpath/classpath.inc
+++ b/recipes-core/classpath/classpath.inc
@@ -21,6 +21,8 @@ RPROVIDES_${PN} = "${PBN}"
 RPROVIDES_${PN}-common = "${PBN}-common"
 RPROVIDES_${PN}-gtk = "${PBN}-awt"
 
+PR = "r1"
+
 SRC_URI = "${GNU_MIRROR}/classpath/classpath-${PV}.tar.gz"
 
 S = "${WORKDIR}/${PBN}-${PV}"

--- a/recipes-core/icedtea/icedtea6-native.inc
+++ b/recipes-core/icedtea/icedtea6-native.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "Harness to build the source code from OpenJDK using Free Software build tools"
 HOMEPAGE = "http://icedtea.classpath.org"
 LICENSE  = "GPL with Classpath Exception"
-INC_PR = "r4"
+INC_PR = "r5"
 
 DEPENDS = "virtual/javac-native virtual/java-native classpath-native \
 	   xalan-j-native xerces-j-native rhino-native \

--- a/recipes-core/jamvm/jamvm-initial_1.4.5.bb
+++ b/recipes-core/jamvm/jamvm-initial_1.4.5.bb
@@ -7,6 +7,8 @@ DEPENDS = "zlib-native classpath-initial jikes-initial libffi-native"
 
 PROVIDES = "virtual/java-initial"
 
+PR = "r1"
+
 S = "${WORKDIR}/jamvm-${PV}"
 
 SRC_URI = "${SOURCEFORGE_MIRROR}/jamvm/jamvm-${PV}.tar.gz \

--- a/recipes-core/jamvm/jamvm_git.bb
+++ b/recipes-core/jamvm/jamvm_git.bb
@@ -6,6 +6,8 @@ require jamvm.inc
 SRCREV = "4617da717ecb05654ea5bb9572338061106a414d"
 PV = "1.5.5+1.6.0-devel+git${SRCPV}"
 
+PR = "r1"
+
 SRC_URI = "git://git.berlios.de/jamvm;protocol=git \
            file://jamvm-jni_h-noinst.patch \
            file://libffi.patch \


### PR DESCRIPTION
This fixes an unpredicability of sysroot tools.zip version as
classpath-initial and classpath-native were installing the tools.zip
at same path.

We also bump PR of affected recipes to force them to rebuild.

Signed-off-by: Otavio Salvador otavio@ossystems.com.br
