### PR TITLE
Fix QA errors when using jamvm instead of zero VM

### DIFF
--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -237,6 +237,7 @@ FILES_${JDKPN}-dbg = "\
         ${JDK_HOME}/jre/lib/${JDK_ARCH}/jamvm/.debug \
 	${JDK_HOME}/jre/lib/${JDK_ARCH}/headless/.debug \
 	${JDK_HOME}/jre/lib/${JDK_ARCH}/xawt/.debug \
+	${JDK_HOME}/jre/lib/${JDK_ARCH}/client/.debug \
        "
 
 FILES_${JDKPN}-demo = "${JDK_HOME}/demo ${JDK_HOME}/sample"


### PR DESCRIPTION
Fixes errors like below when building jamvm as additional VM

ERROR: QA Issue: non debug package contains .debug directory:
openjdk-7-common path
/work/ppce500v2-poky-linux-gnuspe/openjdk-7-jre/03b21-2.1.7-r6.0/packages-split/openjdk-7-common/usr/lib/jvm/java-7-openjdk/jre/lib/ppc/client/.debug/libjvm.so
ERROR: QA run found fatal errors. Please consider fixing them.
ERROR: Function failed: do_package_qa

Signed-off-by: Khem Raj raj.khem@gmail.com
