### PR TITLE
Build and runtime fixes

### DIFF
--- a/recipes-core/classpath/classpath-0.99/freetype2.patch
+++ b/recipes-core/classpath/classpath-0.99/freetype2.patch
@@ -1,0 +1,36 @@
+Index: classpath-0.99/native/jni/gtk-peer/gnu_java_awt_peer_gtk_FreetypeGlyphVector.c
+===================================================================
+--- classpath-0.99.orig/native/jni/gtk-peer/gnu_java_awt_peer_gtk_FreetypeGlyphVector.c	2014-02-10 12:01:26.826613065 +0100
++++ classpath-0.99/native/jni/gtk-peer/gnu_java_awt_peer_gtk_FreetypeGlyphVector.c	2014-02-10 12:01:46.230613171 +0100
+@@ -42,8 +42,9 @@
+ #include <pango/pango.h>
+ #include <pango/pangoft2.h>
+ #include <pango/pangofc-font.h>
+-#include <freetype/ftglyph.h>
+-#include <freetype/ftoutln.h>
++#include <ft2build.h>
++#include FT_GLYPH_H
++#include FT_OUTLINE_H
+ #include "jcl.h"
+ #include "gdkfont.h"
+ #include "gnu_java_awt_peer_gtk_FreetypeGlyphVector.h"
+Index: classpath-0.99/native/jni/gtk-peer/gnu_java_awt_peer_gtk_GdkFontPeer.c
+===================================================================
+--- classpath-0.99.orig/native/jni/gtk-peer/gnu_java_awt_peer_gtk_GdkFontPeer.c	2014-02-10 12:01:21.158613034 +0100
++++ classpath-0.99/native/jni/gtk-peer/gnu_java_awt_peer_gtk_GdkFontPeer.c	2014-02-10 12:01:54.338613216 +0100
+@@ -39,10 +39,11 @@
+ #include <pango/pango.h>
+ #include <pango/pangoft2.h>
+ #include <pango/pangofc-font.h>
+-#include <freetype/ftglyph.h>
+-#include <freetype/ftoutln.h>
+-#include <freetype/fttypes.h>
+-#include <freetype/tttables.h>
++#include <ft2build.h>
++#include FT_GLYPH_H
++#include FT_OUTLINE_H
++#include FT_TYPES_H
++#include FT_TRUETYPE_TABLES_H
+ #include "gdkfont.h"
+ #include "gtkpeer.h"
+ #include "gnu_java_awt_peer_gtk_GdkFontPeer.h"

--- a/recipes-core/classpath/classpath-native_0.99.bb
+++ b/recipes-core/classpath/classpath-native_0.99.bb
@@ -1,9 +1,9 @@
 require classpath-native.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=af0004801732bc4b20d90f351cf80510"
-DEPENDS += "ecj-initial"
+DEPENDS += "ecj-initial virtual/java-initial"
 
-PR = "${INC_PR}.0"
+PR = "${INC_PR}.1"
 
 SRC_URI += " \
             file://sun-security-getproperty.patch;striplevel=0 \

--- a/recipes-core/classpath/classpath-native_0.99.bb
+++ b/recipes-core/classpath/classpath-native_0.99.bb
@@ -1,9 +1,9 @@
 require classpath-native.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=af0004801732bc4b20d90f351cf80510"
-DEPENDS += "ecj-initial virtual/java-initial"
+DEPENDS += "ecj-initial"
 
-PR = "${INC_PR}.1"
+PR = "${INC_PR}.0"
 
 SRC_URI += " \
             file://sun-security-getproperty.patch;striplevel=0 \

--- a/recipes-core/classpath/classpath_0.99.bb
+++ b/recipes-core/classpath/classpath_0.99.bb
@@ -9,6 +9,7 @@ SRC_URI += " \
             file://miscompilation.patch \
             file://toolwrapper-exithook.patch \
             file://use_libdir.patch \
+            file://freetype2.patch \
            "
 
 SRC_URI[md5sum] = "0ae1571249172acd82488724a3b8acb4"

--- a/recipes-core/jakarta-commons/commons-beanutils_1.8.0.bb
+++ b/recipes-core/jakarta-commons/commons-beanutils_1.8.0.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-cli_1.1.bb
+++ b/recipes-core/jakarta-commons/commons-cli_1.1.bb
@@ -1,12 +1,11 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2a944942e1496af1886903d274dedb13"
 
 PR = "${INC_PR}.1"
 
 DESCRIPTION = "Java argument parsing helper classes"
 
 SRC_URI = "http://archive.apache.org/dist/commons/cli/source/${BP}-src.tar.gz"
-
-
 
 SRC_URI[md5sum] = "ccc1aa194132e2387557bbb7f65391f4"
 SRC_URI[sha256sum] = "929eb140c136673e7f5029cd206c81b3c1f5e66bba0dfdcd021b9dd5596356d2"

--- a/recipes-core/jakarta-commons/commons-codec-1.3/commons-codec-1.3/LICENSE.txt
+++ b/recipes-core/jakarta-commons/commons-codec-1.3/commons-codec-1.3/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/recipes-core/jakarta-commons/commons-codec_1.3.bb
+++ b/recipes-core/jakarta-commons/commons-codec_1.3.bb
@@ -1,10 +1,12 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 
 DESCRIPTION = "Java library with simple encoder and decoders for various formats such as Base64 and Hexadecimal"
 
-SRC_URI = "http://archive.apache.org/dist/commons/codec/source/${BP}-src.tar.gz"
+SRC_URI = "http://archive.apache.org/dist/commons/codec/source/${BP}-src.tar.gz \
+           file://${BP}/LICENSE.txt"
 
 S = "${WORKDIR}/${BP}"
 

--- a/recipes-core/jakarta-commons/commons-collections3_3.2.1.bb
+++ b/recipes-core/jakarta-commons/commons-collections3_3.2.1.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-collections_2.1.1.bb
+++ b/recipes-core/jakarta-commons/commons-collections_2.1.1.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-configuration_1.5.bb
+++ b/recipes-core/jakarta-commons/commons-configuration_1.5.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-digester_1.8.bb
+++ b/recipes-core/jakarta-commons/commons-digester_1.8.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=d273d63619c9aeaf15cdaf76422c4f87"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-discovery_0.4.bb
+++ b/recipes-core/jakarta-commons/commons-discovery_0.4.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-el_1.0.bb
+++ b/recipes-core/jakarta-commons/commons-el_1.0.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9147d939b3f3f97692e4441bf20bd1cd"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-fileupload_1.2.1.bb
+++ b/recipes-core/jakarta-commons/commons-fileupload_1.2.1.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-httpclient_3.1.bb
+++ b/recipes-core/jakarta-commons/commons-httpclient_3.1.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=369b6d7c5a954dcc3f2e7ac3323507c3"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-io_1.4.bb
+++ b/recipes-core/jakarta-commons/commons-io_1.4.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fd707e76aa29b6984fbe80629ec55f78"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-jxpath_1.3.bb
+++ b/recipes-core/jakarta-commons/commons-jxpath_1.3.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-lang_2.4.bb
+++ b/recipes-core/jakarta-commons/commons-lang_2.4.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/commons-pool_1.4.bb
+++ b/recipes-core/jakarta-commons/commons-pool_1.4.bb
@@ -1,4 +1,5 @@
 require jakarta-commons.inc
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PR = "${INC_PR}.1"
 

--- a/recipes-core/jakarta-commons/jakarta-commons.inc
+++ b/recipes-core/jakarta-commons/jakarta-commons.inc
@@ -1,7 +1,7 @@
 AUTHOR = "Apache Software Foundation"
 LICENSE = "Apache-2.0"
 
-INC_PR = "r0"
+INC_PR = "r1"
 
 inherit java-library
 

--- a/recipes-core/jamvm/jamvm.inc
+++ b/recipes-core/jamvm/jamvm.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "http://jamvm.sourceforge.net/"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-DEPENDS = "zlib classpath virtual/javac-native libffi virtual/java-initial"
+DEPENDS = "zlib classpath virtual/javac-native libffi"
 DEPENDS_virtclass-native = "zlib-native classpath-native ecj-initial libffi-native"
 
 RDEPENDS_${PN} = "classpath"

--- a/recipes-core/jamvm/jamvm.inc
+++ b/recipes-core/jamvm/jamvm.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "http://jamvm.sourceforge.net/"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-DEPENDS = "zlib classpath virtual/javac-native libffi"
+DEPENDS = "zlib classpath virtual/javac-native libffi virtual/java-initial"
 DEPENDS_virtclass-native = "zlib-native classpath-native ecj-initial libffi-native"
 
 RDEPENDS_${PN} = "classpath"
@@ -21,7 +21,7 @@ SRC_URI = "${SOURCEFORGE_MIRROR}/jamvm/jamvm-${PV}.tar.gz \
           "
 
 
-inherit java autotools update-alternatives
+inherit java autotools update-alternatives pkgconfig
 
 # This uses 32 bit arm, so force the instruction set to arm, not thumb
 ARM_INSTRUCTION_SET = "arm"

--- a/recipes-core/libmatthew/libmatthew.inc
+++ b/recipes-core/libmatthew/libmatthew.inc
@@ -57,7 +57,7 @@ FILES_libcgi-jni = "${libdir_jni}/libcgi-java.so"
 FILES_libcgi-jni-dbg = "${libdir_jni}/.debug/libcgi-java.so"
 RDEPENDS_libcgi-java = "libcgi-jni"
 
-FILES_libunixsocket-java = "${datadir_java}/unix*.jar"
+FILES_libunixsocket-java = "${datadir_java}/unix*.jar ${datadir_java}/libmatthew.jar"
 FILES_libunixsocket-jni = "${libdir_jni}/libunix-java.so"
 FILES_libunixsocket-jni-dbg = "${libdir_jni}/.debug/libunix-java.so"
 RDEPENDS_libunixsocket-java = "libunixsocket-jni"

--- a/recipes-core/libmatthew/libmatthew.inc
+++ b/recipes-core/libmatthew/libmatthew.inc
@@ -34,6 +34,7 @@ do_compile() {
 # create a dummy for install to succeed
 
 JARFILENAME = "unix-${VER_UNIX}.jar"
+ALTJARFILENAMES = "unix.jar"
 
 do_install() {
     oe_jarinstall cgi-${VER_CGI}.jar cgi.jar
@@ -41,7 +42,6 @@ do_install() {
     oe_jarinstall debug-enable-${VER_DEBUG}.jar debug-enable.jar
     oe_jarinstall hexdump-${VER_HEXDUMP}.jar hexdump.jar
     oe_jarinstall io-${VER_IO}.jar io.jar
-    oe_jarinstall unix-${VER_UNIX}.jar unix.jar
     oe_libinstall -so libcgi-java ${D}${libdir_jni}
     oe_libinstall -so libunix-java ${D}${libdir_jni}
 }
@@ -57,7 +57,7 @@ FILES_libcgi-jni = "${libdir_jni}/libcgi-java.so"
 FILES_libcgi-jni-dbg = "${libdir_jni}/.debug/libcgi-java.so"
 RDEPENDS_libcgi-java = "libcgi-jni"
 
-FILES_libunixsocket-java = "${datadir_java}/unix*.jar ${datadir_java}/libmatthew.jar"
+FILES_libunixsocket-java = "${datadir_java}/unix*.jar"
 FILES_libunixsocket-jni = "${libdir_jni}/libunix-java.so"
 FILES_libunixsocket-jni-dbg = "${libdir_jni}/.debug/libunix-java.so"
 RDEPENDS_libunixsocket-java = "libunixsocket-jni"

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -1,7 +1,7 @@
 require openjdk-common.inc
 ICEDTEA = "icedtea-${ICEDTEA_VERSION}"
 
-INC_PR = "r5"
+INC_PR = "r6"
 
 SRC_URI = " \
   ${ICEDTEA_URI} \

--- a/recipes-core/openjdk/openjdk-common.inc
+++ b/recipes-core/openjdk/openjdk-common.inc
@@ -17,7 +17,7 @@ DEPENDS_append_libc-uclibc = " virtual/libiconv "
 # because structure sizes and/or alignment may differ.
 DEPENDS_append = " qemu-native "
 
-inherit java autotools gettext qemu
+inherit java autotools gettext qemu pkgconfig
 
 # OpenJDK uses slightly different names for certain arches. We need to know
 #	this to create some files which are expected by the build.


### PR DESCRIPTION
Hi,

This pull request includes patches needed to build a java2-runtime with the Yocto/Poky master branch.
To run java applications on the target the patches from Amy Fong (see https://www.mail-archive.com/openembedded-devel@lists.openembedded.org/msg34182.html) are also required. Without them the openjdk-7-jre couldn't find the libjli.so library. The patches are also included in this pull request.
The openjdk-7-jre has been tested on a qemux86 image.

Regards,

Martin