### PR TITLE
openjdk7: add icedtea 2.4.5

### DIFF
--- a/recipes-core/openjdk/openjdk-7-51b31/0000_build_hacks.patch
+++ b/recipes-core/openjdk/openjdk-7-51b31/0000_build_hacks.patch
@@ -1,0 +1,47 @@
+--- icedtea-2.4.5/Makefile.am.orig	2014-04-23 09:39:54.890652488 +0200
++++ icedtea-2.4.5/Makefile.am	2014-04-23 10:56:23.043208912 +0200
+@@ -468,6 +468,12 @@
+ 	JAVAC="" \
+ 	JAVA_HOME="" \
+ 	JDK_HOME="" \
++	OE_CFLAGS="$(OE_CFLAGS)" \
++	OE_CPPFLAGS="$(OE_CPPFLAGS)" \
++	OE_CXXFLAGS="$(OE_CXXFLAGS)" \
++	OE_LDFLAGS="$(OE_LDFLAGS)" \
++	OE_LAUNCHER_LDFLAGS="$(OE_LAUNCHER_LDFLAGS)" \
++	DISTRIBUTION_ID="$(DIST_ID)" \
+ 	QUIETLY="" \
+ 	ANT_RESPECT_JAVA_HOME="TRUE" \
+ 	DISTRIBUTION_ID="$(DIST_ID)" \
+@@ -1832,9 +1838,6 @@
+ 	rm -f stamps/add-tzdata-support.stamp
+ 
+ stamps/check-crypto.stamp: stamps/cryptocheck.stamp stamps/icedtea.stamp
+-	if [ -e $(BUILD_OUTPUT_DIR)/j2sdk-image/bin/java ] ; then \
+-	  $(BUILD_OUTPUT_DIR)/j2sdk-image/bin/java -cp $(CRYPTO_CHECK_BUILD_DIR) TestCryptoLevel ; \
+-	fi
+ 	mkdir -p stamps
+ 	touch $@
+ 
+@@ -2283,7 +2286,11 @@
+ if BUILD_JAMVM
+ 	cd jamvm/jamvm && \
+ 	./autogen.sh --with-java-runtime-library=openjdk7 \
+-	  --prefix=$(abs_top_builddir)/jamvm/install ; \
++	  --prefix=$(abs_top_builddir)/jamvm/install \
++	  --host=$(host_alias) \
++	  --build=$(build_alias) \
++	  --target=$(target_alias) \
++	  --with-libtool-sysroot=${ALT_FREETYPE_LIB_PATH} ; \
+ 	$(MAKE) ; \
+ 	$(MAKE) install
+ 	mkdir -p $(abs_top_builddir)/jamvm/install/hotspot/jre/lib/$(INSTALL_ARCH_DIR)/server
+@@ -2415,7 +2422,7 @@
+ # configure script arguments, quoted in single quotes
+ CONFIGURE_ARGS = @CONFIGURE_ARGS@
+ ADD_ZERO_CONFIGURE_ARGS = \
+-	--with-jdk-home=$(BUILD_OUTPUT_DIR)/j2sdk-image \
++	--with-jdk-home=$(abs_top_builddir)/bootstrap/jdk1.7.0 \
+ 	--disable-bootstrap --enable-zero
+ if ADD_SHARK_BUILD
+ ADD_ZERO_CONFIGURE_ARGS += \

--- a/recipes-core/openjdk/openjdk-7-51b31/0001_icedtea-crosscompile-fix.patch
+++ b/recipes-core/openjdk/openjdk-7-51b31/0001_icedtea-crosscompile-fix.patch
@@ -1,0 +1,15 @@
+--- openjdk/jdk/make/java/nio/Makefile.orig
++++ openjdk/jdk/make/java/nio/Makefile
+@@ -973,8 +973,12 @@
+ $(SFS_GEN)/UnixConstants.java: $(GENUC_EXE)
+ 	$(prep-target)
+ 	NAWK="$(NAWK)" SH="$(SH)" $(SH) -e addNotices.sh "$(GENUC_COPYRIGHT_YEARS)" > $@
++ifdef CROSS_COMPILE_ARCH
++	$(QEMU) $(GENUC_EXE) >> $@
++else
+ 	$(GENUC_EXE) >> $@
+ endif
++endif
+ 
+ GENSC_SRC = $(PLATFORM_SRC)/native/sun/nio/fs/genSolarisConstants.c
+ 

--- a/recipes-core/openjdk/openjdk-7-51b31/0002_icedtea-jdk-nio-use-host-cc.patch
+++ b/recipes-core/openjdk/openjdk-7-51b31/0002_icedtea-jdk-nio-use-host-cc.patch
@@ -1,0 +1,29 @@
+--- openjdk/jdk/make/java/nio/Makefile.orig
++++ openjdk/jdk/make/java/nio/Makefile
+@@ -927,7 +927,7 @@
+ 
+ $(GENSOR_EXE) : $(TEMPDIR)/$(GENSOR_SRC)
+ 	$(prep-target)
+-	($(CD) $(TEMPDIR); $(NIO_CC) $(CPPFLAGS) $(LDDFLAGS) \
++	($(CD) $(TEMPDIR); $(CC_FOR_BUILD) $(CPPFLAGS) $(LDDFLAGS) \
+ 	   -o genSocketOptionRegistry$(EXE_SUFFIX) $(GENSOR_SRC))
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+@@ -963,7 +963,7 @@
+ 
+ $(GENUC_EXE) : $(GENUC_SRC)
+ 	$(prep-target)
+-	$(NIO_CC) $(CPPFLAGS) -o $@ $(GENUC_SRC)
++	$(CC_FOR_BUILD) $(CPPFLAGS) -o $@ $(GENUC_SRC)
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+ $(SFS_GEN)/UnixConstants.java: $(NIO_PLATFORM_CLASSES_ROOT_DIR)/sun/nio/fs/UnixConstants-$(PLATFORM)-$(ARCH).java
+@@ -985,7 +985,7 @@
+ 
+ $(GENSC_EXE) : $(GENSC_SRC)
+ 	$(prep-target)
+-	$(NIO_CC) $(CPPFLAGS) -o $@ $(GENSC_SRC)
++	$(CC_FOR_BUILD) $(CPPFLAGS) -o $@ $(GENSC_SRC)
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+ $(SFS_GEN)/SolarisConstants.java: $(NIO_PLATFORM_CLASSES_ROOT_DIR)/sun/nio/fs/SolarisConstants-$(PLATFORM)-$(ARCH).java

--- a/recipes-core/openjdk/openjdk-7-51b31/0003_remove-xawt-subdir.patch
+++ b/recipes-core/openjdk/openjdk-7-51b31/0003_remove-xawt-subdir.patch
@@ -1,0 +1,20 @@
+--- openjdk/jdk/make/sun/Makefile.orig
++++ openjdk/jdk/make/sun/Makefile
+@@ -55,7 +55,7 @@
+     endif
+   endif
+   HEADLESS_SUBDIR = headless
+-  XAWT_SUBDIR     = xawt
++  XAWT_SUBDIR     =
+ endif
+ 
+ ifeq ($(PLATFORM), macosx)
+@@ -87,7 +87,7 @@
+ endif
+ SUBDIRS_desktop    = audio $(RENDER_SUBDIR) image \
+                      $(LWAWT_PRE_SUBDIR) $(DISPLAY_LIBS) $(DGA_SUBDIR) $(LWAWT_SUBDIR) \
+-                     jawt font jpeg cmm $(DISPLAY_TOOLS) beans
++                     font jpeg cmm $(DISPLAY_TOOLS) beans
+ SUBDIRS_management = management
+ SUBDIRS_misc       = $(ORG_SUBDIR) rmi $(JDBC_SUBDIR) tracing
+ SUBDIRS_tools      = native2ascii serialver tools jconsole

--- a/recipes-core/openjdk/openjdk-7-51b31/jvm.cfg
+++ b/recipes-core/openjdk/openjdk-7-51b31/jvm.cfg
@@ -1,0 +1,43 @@
+# Copyright 2003 Sun Microsystems, Inc.  All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Sun designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Sun in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+# CA 95054 USA or visit www.sun.com if you need additional information or
+# have any questions.
+#
+# 
+# List of JVMs that can be used as an option to java, javac, etc.
+# Order is important -- first in this list is the default JVM.
+# NOTE that this both this file and its format are UNSUPPORTED and
+# WILL GO AWAY in a future release.
+#
+# You may also select a JVM in an arbitrary location with the
+# "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
+# and may not be available in a future release.
+#
+-server ERROR
+-client IGNORE
+-hotspot ERROR
+-classic WARN
+-native ERROR
+-green ERROR
+-zero ALIASED_TO -server
+-shark ERROR
+-cacao ERROR
+-jamvm ERROR

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -26,7 +26,7 @@ PN = "${JDKPN}-jre"
 PROVIDES += "${JDKPN}"
 
 DEPENDS = " \
-           icedtea6-native zip-native ant-native \
+           icedtea7-native zip-native ant-native \
            zlib \
 	   jpeg libpng giflib \
            gtk+ glib-2.0 \
@@ -101,7 +101,7 @@ EXTRA_OECONF = " \
 	\
         --enable-zero \
 	\
-	--with-jdk-home=${STAGING_LIBDIR_JVM_NATIVE}/icedtea6-native \
+	--with-jdk-home=${STAGING_LIBDIR_JVM_NATIVE}/icedtea7-native \
 	--with-rhino=${STAGING_DATADIR_JAVA}/rhino.jar \
 	\
         --with-openjdk-src-zip=${WORKDIR}/${OPENJDK_FILE} \
@@ -226,6 +226,7 @@ PACKAGES = " \
 FILES_${JDKPN}-dbg = "\
 	${JDK_HOME}/bin/.debug \
 	${JDK_HOME}/lib/.debug \
+	${JDK_HOME}/lib/${JDK_ARCH}/jli/.debug \
 	${JDK_HOME}/jre/bin/.debug \
 	${JDK_HOME}/jre/lib/.debug \
 	${JDK_HOME}/jre/lib/${JDK_ARCH}/.debug \

--- a/recipes-core/openjdk/openjdk-7-release-51b31.inc
+++ b/recipes-core/openjdk/openjdk-7-release-51b31.inc
@@ -1,0 +1,78 @@
+require openjdk-7-common.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
+
+FILESPATH =. "${FILE_DIRNAME}/openjdk-7-51b31:"
+
+# Name of the directory containing the compiled output
+BUILD_DIR = "openjdk.build"
+BUILD_DIR_ECJ = "openjdk.build-ecj"
+
+# Force arm mode for now
+ARM_INSTRUCTION_SET_armv4t = "ARM"
+
+ICEDTEA_URI = "http://icedtea.wildebeest.org/download/source/${ICEDTEA}.tar.gz;name=iced"
+
+ICEDTEA_PREFIX = "icedtea7-forest-2.4"
+ICEDTEA_HG_URL = "http://icedtea.classpath.org/hg/release/${ICEDTEA_PREFIX}"
+
+OPENJDK_FILE = "${OPENJDK_CHANGESET}.tar.bz2"
+OPENJDK_URI = "${ICEDTEA_HG_URL}/archive/${OPENJDK_FILE};name=openjdk;unpack=false"
+
+HOTSPOT_FILE = "${HOTSPOT_CHANGESET}.tar.gz"
+HOTSPOT_URI = "${ICEDTEA_HG_URL}/hotspot/archive/${HOTSPOT_FILE};name=hotspot;unpack=false"
+
+CORBA_FILE = "${CORBA_CHANGESET}.tar.gz"
+CORBA_URI = "${ICEDTEA_HG_URL}/corba/archive/${CORBA_FILE};name=corba;unpack=false"
+
+JAXP_FILE = "${JAXP_CHANGESET}.tar.gz"
+JAXP_URI = "${ICEDTEA_HG_URL}/jaxp/archive/${JAXP_FILE};name=jaxp;unpack=false"
+
+JAXWS_FILE = "${JAXWS_CHANGESET}.tar.gz"
+JAXWS_URI = "${ICEDTEA_HG_URL}/jaxws/archive/${JAXWS_FILE};name=jaxws;unpack=false"
+
+JDK_FILE = "${JDK_CHANGESET}.tar.gz"
+JDK_URI = "${ICEDTEA_HG_URL}/jdk/archive/${JDK_FILE};name=jdk;unpack=false"
+
+LANGTOOLS_FILE = "${LANGTOOLS_CHANGESET}.tar.gz"
+LANGTOOLS_URI = "${ICEDTEA_HG_URL}/langtools/archive/${LANGTOOLS_FILE};name=langtools;unpack=false"
+
+CACAO_VERSION = "e215e36be9fc"
+CACAO_FILE = "${CACAO_VERSION}.tar.gz"
+CACAO_URI = "http://icedtea.wildebeest.org/download/drops/cacao/${CACAO_FILE};name=cacao;unpack=false"
+SRC_URI[cacao.md5sum] = "79f95f0aea4ba04cf2f1a8632ac66d14"
+SRC_URI[cacao.sha256sum] = "4966514c72ee7ed108b882d9b6e65c3adf8a8f9c2dccb029f971b3c8cb4870ab"
+
+JAMVM_VERSION = "ac22c9948434e528ece451642b4ebde40953ee7e"
+JAMVM_FILE = "jamvm-${JAMVM_VERSION}.tar.gz"
+JAMVM_URI = "http://icedtea.wildebeest.org/download/drops/jamvm/${JAMVM_FILE};name=jamvm;unpack=false"
+SRC_URI[jamvm.md5sum] = "3a67d0f3471bd2d5b2446d91bfa73f73"
+SRC_URI[jamvm.sha256sum] = "4662da1fe3e0e11d8fa685c7f2fc748576b9f3d3e37dc56b798dd6a5bd6b61e7"
+
+# overrride the jamvm patch for now, needs to be solved upstream
+#do_unpackpost() {
+#	cp ${WORKDIR}/remove-sun.misc.Perf-debug-code.patch ${S}/patches/jamvm
+#	rm -f ${S}/patches/rhino.patch
+#	pwd
+#}
+#
+#addtask unpackpost after do_unpack before do_patch
+
+# Allow overriding this separately
+OEPATCHES = "\
+		file://0000_build_hacks.patch \
+	"
+
+# Allow overriding this separately
+ICEDTEAPATCHES = "\
+		file://0002_icedtea-jdk-nio-use-host-cc.patch;apply=no \
+		file://0003_remove-xawt-subdir.patch;apply=no \
+	"
+
+# Allow overriding this separately
+DISTRIBUTION_PATCHES = "\
+		../0002_icedtea-jdk-nio-use-host-cc.patch \
+		../0003_remove-xawt-subdir.patch \
+	"
+
+export DISTRIBUTION_PATCHES

--- a/recipes-core/openjdk/openjdk-7_51b31-2.4.5.bb
+++ b/recipes-core/openjdk/openjdk-7_51b31-2.4.5.bb
@@ -1,0 +1,36 @@
+require openjdk-7-release-51b31.inc
+
+PR = "${INC_PR}.0"
+
+SRC_URI[iced.md5sum] = "6dcc544657ade213d01017354a6f9858"
+SRC_URI[iced.sha256sum] = "10c08eeffaa0602b23cb957a2595a2ad3ab474cbe47b12743bbdd79037d5883d"
+
+CORBA_CHANGESET = "ea108ff3be9a"
+SRC_URI[corba.md5sum] = "f76840f24d112a8fe259cb4122415a25"
+SRC_URI[corba.sha256sum] = "818f5613b218fe2a2036e6c65622b970839986c0c1ca95563f911b379a52b765"
+
+JAXP_CHANGESET = "332f0234a53e"
+SRC_URI[jaxp.md5sum] = "1b11d9fa16e7bf7613a8b9d32f6a586a"
+SRC_URI[jaxp.sha256sum] = "a3f99615331cdc3d5e38e7169bb4b03dc43ede25c73834114240b8768207b9dc"
+
+JAXWS_CHANGESET = "fdc4ad9f30c6"
+SRC_URI[jaxws.md5sum] = "f6eb8fcbf99d0914149b0e2deac0e34c"
+SRC_URI[jaxws.sha256sum] = "b149c1fab323a586eae9b4459ccd929f0db8b35769e42dd7f4fbadc48b803dab"
+
+JDK_CHANGESET = "4a0cf2c05cc6"
+SRC_URI[jdk.md5sum] = "89f3dac9c06581fd8b4f1b1103a6c2f9"
+SRC_URI[jdk.sha256sum] = "badbbf50c820325ffe592762a2eff3414df71e286460b75716a2100d7f6f2aa0"
+
+LANGTOOLS_CHANGESET = "6c9b532f4281"
+SRC_URI[langtools.md5sum] = "e932425860de3b52358cff66b9ceadbf"
+SRC_URI[langtools.sha256sum] = "b9e2e3c97393f566b0c4dc2b0ca826bfb3b3841f5522a850b82d1ff23745839b"
+
+OPENJDK_CHANGESET = "e62743867f54"
+SRC_URI[openjdk.md5sum] = "5680583c82703031d6acb0a141fd328f"
+SRC_URI[openjdk.sha256sum] = "d1132bdde0e19d8e4d2516213bce7aa50b4b6d1ab04a82bf7a0440d6184db842"
+
+# located in hotspot.map
+HOTSPOT_CHANGESET = "37b254871acb"
+SRC_URI[hotspot.md5sum] = "57f2077c4d4237de44b788e0a8456c83"
+SRC_URI[hotspot.sha256sum] = "60268f9d792575ec26b8796753246aca70282937327c2fa855b3f0010638605e"
+


### PR DESCRIPTION
Hi,
I've added some recipes for IcedTea 2.4.5. Please take a closer look at them!

I've tested the build only for ARMv7, but therefore it works well:
```
root@arm7:~# java -version
java version "1.7.0_51"
OpenJDK Runtime Environment (IcedTea 2.4.5) (51b31-2.4.5)
OpenJDK Zero VM (build 24.51-b03, interpreted mode)
```

I'm awaiting your comments and feedback!

regards,
Richard