### PR TITLE
Revert "openjdk-7-release-25b30.inc: move nio patch to main section."

### DIFF
--- a/recipes-core/openjdk/openjdk-7-release-25b30.inc
+++ b/recipes-core/openjdk/openjdk-7-release-25b30.inc
@@ -78,14 +78,15 @@ ICEDTEAPATCHES = "\
 	file://icedtea-shark-arm-linux-cpu-detection.patch;apply=no \
 	file://icedtea-corba-parallel-make.patch;apply=no \
         file://icedtea-zero-hotspotfix.patch;apply=no \
-	file://icedtea-jdk-nio-use-host-cc.patch;apply=no \
         file://icedtea-unset-NIO_PLATFORM_CLASSES_ROOT_DIR.patch;apply=no \
 	"
 ICEDTEAPATCHES_append_powerpc = " \
+	file://icedtea-jdk-nio-use-host-cc.patch;apply=no \
 	file://icedtea-jdk-ppc64-jvm-cfg.patch;apply=no \
 	file://icedtea-jdk-powerpc-atomic64.patch;apply=no \
         "
 ICEDTEAPATCHES_append_powerpc64 = " \
+	file://icedtea-jdk-nio-use-host-cc.patch;apply=no \
 	file://icedtea-jdk-ppc64-jvm-cfg.patch;apply=no \
         "
 ICEDTEAPATCHES_append_libc-uclibc = " \
@@ -108,7 +109,6 @@ DISTRIBUTION_PATCHES = "\
 	patches/icedtea-shark-arm-linux-cpu-detection.patch \
 	patches/icedtea-corba-parallel-make.patch \
         patches/icedtea-zero-hotspotfix.patch \
-	patches/icedtea-jdk-nio-use-host-cc.patch \
 	patches/icedtea-unset-NIO_PLATFORM_CLASSES_ROOT_DIR.patch \
 	"
 
@@ -124,10 +124,12 @@ DISTRIBUTION_PATCHES_append_libc-uclibc = "\
         "
 
 DISTRIBUTION_PATCHES_append_powerpc = " \
+	patches/icedtea-jdk-nio-use-host-cc.patch \
 	patches/icedtea-jdk-ppc64-jvm-cfg.patch \
 	patches/icedtea-jdk-powerpc-atomic64.patch \
         "
 DISTRIBUTION_PATCHES_append_powerpc64 = " \
+	patches/icedtea-jdk-nio-use-host-cc.patch \
 	patches/icedtea-jdk-ppc64-jvm-cfg.patch \
         "
 export DISTRIBUTION_PATCHES

--- a/recipes-core/openjdk/openjdk-common.inc
+++ b/recipes-core/openjdk/openjdk-common.inc
@@ -72,6 +72,6 @@ export WANT_LLVM_RELEASE = "2.8"
 export LLVM_CONFIGURE_ARCH="${@get_llvm_configure_arch(d)}"
 
 # Large stack is required at least on x86_64 host, otherwise random segfaults appear:
-QEMU = "${@qemu_target_binary(d)} ${QEMU_OPTIONS} -s 2097152"
+QEMU = "${@qemu_target_binary(d)} ${QEMU_OPTIONS} -s 2097152 -L ${STAGING_DIR_TARGET} -E LD_LIBRARY_PATH=${STAGING_BASELIBDIR}"
 
 EXTRA_OEMAKE += 'QEMU="${QEMU}"'


### PR DESCRIPTION
This reverts commit 83096c2ebba8e17cde48058931caa1211fa8c080 and adds the staging dir commandline setting to the qemu call again (which were removed in commit 6c01d9fa201b5578d64650c0fdab1c13a82a0c42).

GitHub: This will hopefully fix #60

Conflicts:
	recipes-core/openjdk/openjdk-7-release-25b30.inc