### PR TITLE
IcedTea 2.4.7 using OpenJDK 7u55

### DIFF
--- a/recipes-core/openjdk/openjdk-7-55b14/0000_build_hacks.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0000_build_hacks.patch
@@ -1,0 +1,47 @@
+--- icedtea-2.4.5/Makefile.am.orig	2014-04-23 09:39:54.890652488 +0200
++++ icedtea-2.4.5/Makefile.am	2014-04-23 10:56:23.043208912 +0200
+@@ -468,6 +468,12 @@
+ 	JAVAC="" \
+ 	JAVA_HOME="" \
+ 	JDK_HOME="" \
++	OE_CFLAGS="$(OE_CFLAGS)" \
++	OE_CPPFLAGS="$(OE_CPPFLAGS)" \
++	OE_CXXFLAGS="$(OE_CXXFLAGS)" \
++	OE_LDFLAGS="$(OE_LDFLAGS)" \
++	OE_LAUNCHER_LDFLAGS="$(OE_LAUNCHER_LDFLAGS)" \
++	DISTRIBUTION_ID="$(DIST_ID)" \
+ 	QUIETLY="" \
+ 	ANT_RESPECT_JAVA_HOME="TRUE" \
+ 	DISTRIBUTION_ID="$(DIST_ID)" \
+@@ -1832,9 +1838,6 @@
+ 	rm -f stamps/add-tzdata-support.stamp
+ 
+ stamps/check-crypto.stamp: stamps/cryptocheck.stamp stamps/icedtea.stamp
+-	if [ -e $(BUILD_OUTPUT_DIR)/j2sdk-image/bin/java ] ; then \
+-	  $(BUILD_OUTPUT_DIR)/j2sdk-image/bin/java -cp $(CRYPTO_CHECK_BUILD_DIR) TestCryptoLevel ; \
+-	fi
+ 	mkdir -p stamps
+ 	touch $@
+ 
+@@ -2283,7 +2286,11 @@
+ if BUILD_JAMVM
+ 	cd jamvm/jamvm && \
+ 	./autogen.sh --with-java-runtime-library=openjdk7 \
+-	  --prefix=$(abs_top_builddir)/jamvm/install ; \
++	  --prefix=$(abs_top_builddir)/jamvm/install \
++	  --host=$(host_alias) \
++	  --build=$(build_alias) \
++	  --target=$(target_alias) \
++	  --with-libtool-sysroot=${ALT_FREETYPE_LIB_PATH} ; \
+ 	$(MAKE) ; \
+ 	$(MAKE) install
+ 	mkdir -p $(abs_top_builddir)/jamvm/install/hotspot/jre/lib/$(INSTALL_ARCH_DIR)/server
+@@ -2415,7 +2422,7 @@
+ # configure script arguments, quoted in single quotes
+ CONFIGURE_ARGS = @CONFIGURE_ARGS@
+ ADD_ZERO_CONFIGURE_ARGS = \
+-	--with-jdk-home=$(BUILD_OUTPUT_DIR)/j2sdk-image \
++	--with-jdk-home=$(abs_top_builddir)/bootstrap/jdk1.7.0 \
+ 	--disable-bootstrap --enable-zero
+ if ADD_SHARK_BUILD
+ ADD_ZERO_CONFIGURE_ARGS += \

--- a/recipes-core/openjdk/openjdk-7-55b14/0001_hotspot-fix-zeroshark-build.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0001_hotspot-fix-zeroshark-build.patch
@@ -1,0 +1,27 @@
+--- openjdk/hotspot/make/linux/makefiles/zeroshark.make
++++ openjdk/hotspot/make/linux/makefiles/zeroshark.make
+@@ -39,20 +39,20 @@
+ 
+ offsets_arm.s:	mkoffsets
+ 	@echo Generating assembler offsets
+-	./mkoffsets > $@
++	$(QEMU) ./mkoffsets > $@
+ 
+ bytecodes_arm.s: bytecodes_arm.def mkbc
+ 	@echo Generating ARM assembler bytecode sequences
+-	$(CXX_COMPILE) -E -x c++ - < $< | ./mkbc - $@ $(COMPILE_DONE)
++	$(CXX_COMPILE) $(CFLAGS) -E -x c++ - < $< | $(QEMU) ./mkbc - $@ $(COMPILE_DONE)
+ 
+ mkbc:	$(GAMMADIR)/tools/mkbc.c
+ 	@echo Compiling mkbc tool
+-	$(CC_COMPILE) -o $@ $< $(COMPILE_DONE)
++	$(CXX_COMPILE) -static -o $@ $< $(COMPILE_DONE)
+ 
+ mkoffsets:	asm_helper.cpp
+ 	@echo Compiling offset generator
+ 	$(QUIETLY) $(REMOVE_TARGET)
+-	$(CXX_COMPILE) -DSTATIC_OFFSETS -o $@ $< $(COMPILE_DONE)
++	$(CXX_COMPILE) $(CFLAGS) -DSTATIC_OFFSETS -static -o $@ $< $(COMPILE_DONE)
+ 
+ endif
+ endif

--- a/recipes-core/openjdk/openjdk-7-55b14/0002_jdk-fix-nio-gensor-genuc-gensc-build.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0002_jdk-fix-nio-gensor-genuc-gensc-build.patch
@@ -1,0 +1,29 @@
+--- openjdk/jdk/make/java/nio/Makefile	2014-04-12 01:23:06.000000000 +0200
++++ openjdk/jdk/make/java/nio/Makefile	2014-05-06 08:22:51.693861161 +0200
+@@ -927,7 +927,7 @@
+ 
+ $(GENSOR_EXE) : $(TEMPDIR)/$(GENSOR_SRC)
+ 	$(prep-target)
+-	($(CD) $(TEMPDIR); $(NIO_CC) $(CPPFLAGS) $(LDDFLAGS) \
++	($(CD) $(TEMPDIR); $(NIO_CC) $(CPPFLAGS) -static $(LDDFLAGS) \
+ 	   -o genSocketOptionRegistry$(EXE_SUFFIX) $(GENSOR_SRC))
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+@@ -963,7 +963,7 @@
+ 
+ $(GENUC_EXE) : $(GENUC_SRC)
+ 	$(prep-target)
+-	$(NIO_CC) $(CPPFLAGS) -o $@ $(GENUC_SRC)
++	$(NIO_CC) $(CPPFLAGS) -static -o $@ $(GENUC_SRC)
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+ $(SFS_GEN)/UnixConstants.java: $(NIO_PLATFORM_CLASSES_ROOT_DIR)/sun/nio/fs/UnixConstants-$(PLATFORM)-$(ARCH).java
+@@ -985,7 +985,7 @@
+ 
+ $(GENSC_EXE) : $(GENSC_SRC)
+ 	$(prep-target)
+-	$(NIO_CC) $(CPPFLAGS) -o $@ $(GENSC_SRC)
++	$(NIO_CC) $(CPPFLAGS) -static -o $@ $(GENSC_SRC)
+ 
+ ifdef NIO_PLATFORM_CLASSES_ROOT_DIR
+ $(SFS_GEN)/SolarisConstants.java: $(NIO_PLATFORM_CLASSES_ROOT_DIR)/sun/nio/fs/SolarisConstants-$(PLATFORM)-$(ARCH).java

--- a/recipes-core/openjdk/openjdk-7-55b14/0003_hotspot-div-crosscompile-fixes.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0003_hotspot-div-crosscompile-fixes.patch
@@ -1,0 +1,70 @@
+--- openjdk/hotspot/make/linux/makefiles/build_vm_def.sh
++++ openjdk/hotspot/make/linux/makefiles/build_vm_def.sh
+@@ -1,10 +1,12 @@
+ #!/bin/sh
+ 
+ # If we're cross compiling use that path for nm
+-if [ "$CROSS_COMPILE_ARCH" != "" ]; then 
+-NM=$ALT_COMPILER_PATH/nm
+-else
+-NM=nm
++if [ "$NM" == "" ]; then
++  if [ "$CROSS_COMPILE_ARCH" != "" ]; then 
++    NM=$ALT_COMPILER_PATH/nm
++  else
++    NM=nm
++  fi
+ fi
+ 
+ $NM --defined-only $* \
+--- openjdk/hotspot/make/linux/makefiles/gcc.make
++++ openjdk/hotspot/make/linux/makefiles/gcc.make
+@@ -164,7 +164,7 @@ CFLAGS_WARN/DEFAULT = $(WARNINGS_ARE_ERRORS) $(ACCEPTABLE_WARNINGS)
+ CFLAGS_WARN/BYFILE = $(CFLAGS_WARN/$@)$(CFLAGS_WARN/DEFAULT$(CFLAGS_WARN/$@)) 
+ 
+ # The flags to use for an Optimized g++ build
+-OPT_CFLAGS += -O3
++OPT_CFLAGS += $(OE_CFLAGS)
+ 
+ # Hotspot uses very unstrict aliasing turn this optimization off
+ OPT_CFLAGS += -fno-strict-aliasing
+@@ -208,15 +208,7 @@ LFLAGS += -Wl,-relax
+ endif
+ 
+ # Enable linker optimization
+-LFLAGS += -Xlinker -O1
+-
+-# If this is a --hash-style=gnu system, use --hash-style=both
+-#   The gnu .hash section won't work on some Linux systems like SuSE 10.
+-_HAS_HASH_STYLE_GNU:=$(shell $(CC) -dumpspecs | grep -- '--hash-style=gnu')
+-ifneq ($(_HAS_HASH_STYLE_GNU),)
+-  LDFLAGS_HASH_STYLE = -Wl,--hash-style=both
+-endif
+-LFLAGS += $(LDFLAGS_HASH_STYLE)
++LFLAGS += $(OE_LDFLAGS)
+ 
+ # Use $(MAPFLAG:FILENAME=real_file_name) to specify a map file.
+ MAPFLAG = -Xlinker --version-script=FILENAME
+--- openjdk/hotspot/make/linux/makefiles/launcher.make
++++ openjdk/hotspot/make/linux/makefiles/launcher.make
+@@ -50,8 +50,8 @@ ifeq ($(LINK_INTO),AOUT)
+   LIBS_LAUNCHER             += $(STATIC_STDCXX) $(LIBS)
+ else
+   LAUNCHER.o                 = launcher.o
+-  LFLAGS_LAUNCHER           += -L `pwd`
+-  LIBS_LAUNCHER             += -l$(JVM) $(LIBS)
++  LFLAGS_LAUNCHER           += -L `pwd` $(OE_LAUNCHER_LDFLAGS) $(OE_LDFLAGS)
++  LIBS_LAUNCHER             += -l$(JVM) $(LIBS) -lstdc++
+ endif
+ 
+ LINK_LAUNCHER = $(LINK.CC)
+--- openjdk/hotspot/make/linux/makefiles/vm.make
++++ openjdk/hotspot/make/linux/makefiles/vm.make
+@@ -292,6 +292,7 @@
+   LFLAGS_VM += $(LLVM_LDFLAGS)
+ endif
+ 
++LFLAGS_VM += $(OE_LDFLAGS)
+ LINK_VM = $(LINK_LIB.CC)
+ 
+ # rule for building precompiled header

--- a/recipes-core/openjdk/openjdk-7-55b14/0004_corba-fix-crosscompile.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0004_corba-fix-crosscompile.patch
@@ -1,0 +1,19 @@
+--- openjdk/corba/make/common/shared/Platform.gmk	2014-01-21 13:46:58.000000000 +0100
++++ openjdk/corba/make/common/shared/Platform.gmk	2014-05-06 08:51:53.128748151 +0200
+@@ -152,9 +152,13 @@
+   OS_NAME = linux
+   OS_VERSION := $(shell uname -r)
+   # Arch and OS name/version
+-  mach := $(shell uname -m)
+-  ifneq (,$(wildcard /usr/bin/dpkg-architecture))
+-    mach := $(shell (dpkg-architecture -qDEB_HOST_ARCH_CPU 2>/dev/null || echo $(mach)) | sed 's/arm64/aarch64/;s/powerpc$$/ppc/;s/hppa/parisc/;s/ppc64el/ppc64le/')
++  ifdef CROSS_COMPILE_ARCH
++    mach := $(CROSS_COMPILE_ARCH)
++  else
++    mach := $(shell uname -m)
++    ifneq (,$(wildcard /usr/bin/dpkg-architecture))
++      mach := $(shell (dpkg-architecture -qDEB_HOST_ARCH_CPU 2>/dev/null || echo $(mach)) | sed 's/arm64/aarch64/;s/powerpc$$/ppc/;s/hppa/parisc/;s/ppc64el/ppc64le/')
++    endif
+   endif
+   archExpr = case "$(mach)" in \
+                 i[3-9]86) \

--- a/recipes-core/openjdk/openjdk-7-55b14/0005_jdk-div-crosscompile-fixes.patch
+++ b/recipes-core/openjdk/openjdk-7-55b14/0005_jdk-div-crosscompile-fixes.patch
@@ -1,0 +1,255 @@
+--- openjdk/jdk/make/common/shared/Platform.gmk
++++ openjdk/jdk/make/common/shared/Platform.gmk
+@@ -159,9 +159,9 @@
+     mach := $(CROSS_COMPILE_ARCH)
+   else
+     mach := $(shell uname -m)
+-  endif
+-  ifneq (,$(wildcard /usr/bin/dpkg-architecture))
+-    mach := $(shell (dpkg-architecture -qDEB_HOST_ARCH_CPU 2>/dev/null || echo $(mach)) | sed 's/arm64/aarch64/;s/powerpc$$/ppc/;s/hppa/parisc/;s/ppc64el/ppc64le/')
++    ifneq (,$(wildcard /usr/bin/dpkg-architecture))
++      mach := $(shell (dpkg-architecture -qDEB_HOST_ARCH_CPU 2>/dev/null || echo $(mach)) | sed 's/arm64/aarch64/;s/powerpc$$/ppc/;s/hppa/parisc/;s/ppc64el/ppc64le/')
++    endif
+   endif
+   archExpr = case "$(mach)" in \
+                 i[3-9]86) \
+--- openjdk/jdk/make/java/nio/Makefile
++++ openjdk/jdk/make/java/nio/Makefile
+@@ -934,8 +934,12 @@ else
+ $(SCH_GEN)/SocketOptionRegistry.java: $(GENSOR_EXE)
+ 	$(prep-target)
+ 	NAWK="$(NAWK)" SH="$(SH)" $(SH) -e addNotices.sh "$(SOR_COPYRIGHT_YEARS)" > $@
++ifdef CROSS_COMPILE_ARCH
++	$(QEMU) $(GENSOR_EXE) >> $@
++else
+ 	$(GENSOR_EXE) >> $@
+ endif
++endif
+ #
+ # Generated sun.nio.cs SingleByte classes
+ #
+@@ -969,8 +973,12 @@ else
+ $(SFS_GEN)/UnixConstants.java: $(GENUC_EXE)
+ 	$(prep-target)
+ 	NAWK="$(NAWK)" SH="$(SH)" $(SH) -e addNotices.sh "$(GENUC_COPYRIGHT_YEARS)" > $@
++ifdef CROSS_COMPILE_ARCH
++	$(QEMU) $(GENUC_EXE) >> $@
++else
+ 	$(GENUC_EXE) >> $@
+ endif
++endif
+ 
+ GENSC_SRC = $(PLATFORM_SRC)/native/sun/nio/fs/genSolarisConstants.c
+ 
+@@ -991,7 +999,11 @@ else
+ $(SFS_GEN)/SolarisConstants.java: $(GENSC_EXE)
+ 	$(prep-target)
+ 	NAWK="$(NAWK)" SH="$(SH)" $(SH) -e addNotices.sh "$(GENSC_COPYRIGHT_YEARS)" > $@
++ifdef CROSS_COMPILE_ARCH
++	$(QEMU) $(GENSC_EXE) >> $@
++else
+ 	$(GENSC_EXE) >> $@
+ endif
++endif
+ 
+ .PHONY: sources 
+--- openjdk/jdk/make/sun/awt/mawt.gmk
++++ openjdk/jdk/make/sun/awt/mawt.gmk
+@@ -151,22 +151,6 @@ else
+ #endif
+ 
+ LIBXTST = -lXtst
+-ifeq ($(PLATFORM), linux)
+-   ifeq ($(ARCH_DATA_MODEL), 64)
+-   # XXX what about the rest of them?
+-        LIBXT = -lXt
+-    else
+-    # Allows for builds on Debian GNU Linux, X11 is in a different place 
+-       LIBXT = $(firstword $(wildcard $(OPENWIN_LIB)/libXt.a) \
+-                        $(wildcard /usr/lib/libXt.a))
+-       LIBSM = $(firstword $(wildcard $(OPENWIN_LIB)/libSM.a) \
+-                        $(wildcard /usr/lib/libSM.a))
+-       LIBICE = $(firstword $(wildcard $(OPENWIN_LIB)/libICE.a) \
+-                         $(wildcard /usr/lib/libICE.a))
+-       LIBXTST = $(firstword $(wildcard $(OPENWIN_LIB)/libXtst.a) \
+-                         $(wildcard /usr/lib/libXtst.a))
+-   endif
+-endif
+ 
+ # Use -lXmu for EditRes support
+ LIBXMU_DBG	= -lXmu
+@@ -181,7 +165,7 @@ ifneq (,$(findstring $(PLATFORM), linux macosx))
+ OTHER_CFLAGS += -DMLIB_NO_LIBSUNMATH
+ # XXX what is this define below? Isn't it motif-related?
+ OTHER_CFLAGS += -DXMSTRINGDEFINES=1
+-OTHER_LDLIBS =  $(LIBXMU) $(LIBXTST) -lXext $(LIBXT) $(LIBSM) $(LIBICE) -lX11 -lXi
++OTHER_LDLIBS =  $(LIBXMU) $(LIBXTST) -lXext -lXt -lSM -lICE -lXi -lX11
+ endif
+ 
+ endif
+@@ -230,12 +214,6 @@ else
+   CPPFLAGS += -I$(PLATFORM_SRC)/native/common/deps/fontconfig2
+ endif
+ 
+-ifndef HEADLESS
+-CPPFLAGS += -I$(OPENWIN_HOME)/include 
+-LDFLAGS  += -L$(OPENWIN_LIB)
+-
+-endif # !HEADLESS
+-
+ CPPFLAGS += -I$(SHARE_SRC)/native/$(PKGDIR)/debug \
+             -I$(SHARE_SRC)/native/$(PKGDIR)/../font \
+             -I$(PLATFORM_SRC)/native/$(PKGDIR)/../font \
+@@ -269,12 +247,6 @@ LDFLAGS  += -L$(MOTIF_LIB) -L$(OPENWIN_LIB)
+ endif # !HEADLESS
+ endif # PLATFORM
+ 
+-ifeq ($(PLATFORM), linux)
+-  # Checking for the X11/extensions headers at the additional location
+-  CPPFLAGS += -I$(firstword $(wildcard $(OPENWIN_HOME)/include/X11/extensions) \
+-                        $(wildcard /usr/include/X11/extensions))
+-endif
+-
+ ifeq ($(PLATFORM), macosx))
+   CPPFLAGS += -I$(OPENWIN_HOME)/include/X11/extensions \
+               -I$(OPENWIN_HOME)/include 
+--- openjdk/jdk/make/sun/xawt/Makefile
++++ openjdk/jdk/make/sun/xawt/Makefile
+@@ -198,20 +198,6 @@
+   CPPFLAGS += -I$(PLATFORM_SRC)/native/common/deps/glib2
+ endif
+ 
+-ifeq ($(PLATFORM), linux)
+-  ifndef CROSS_COMPILE_ARCH
+-    # Allows for builds on Debian GNU Linux, X11 is in a different place 
+-    # This should really be handled at a higher-level so we don't have to
+-    # work-around this when cross-compiling
+-    CPPFLAGS += -I/usr/X11R6/include/X11/extensions \
+-                -I/usr/include/X11/extensions \
+-                -I$(OPENWIN_HOME)/include 
+-  else
+-    CPPFLAGS += -I$(OPENWIN_HOME)/include/X11/extensions \
+-                -I$(OPENWIN_HOME)/include 
+-  endif
+-endif
+-
+ # We have some odd logic here because some Solaris 10 updates
+ # have a render.h file that suggests gradients are supported, but
+ # the Xrender.h doesn't have the corresponding type definitions.
+@@ -292,16 +278,10 @@
+ SIZERS = $(SIZER).32
+ SIZERS_C = $(SIZER_32_C)
+ SIZES = $(WRAPPER_GENERATOR_DIR)/sizes.32
+-ifdef CROSS_COMPILE_ARCH
+-CFLAGS_32 = -m32
+-endif
+ else # !32
+ SIZERS = $(SIZER).64
+ SIZERS_C = $(SIZER_64_C)
+ SIZES = $(WRAPPER_GENERATOR_DIR)/sizes.64
+-ifdef CROSS_COMPILE_ARCH
+-CFLAGS_64 = -m64
+-endif
+ endif # 32
+ endif # !macosx
+ endif # solaris
+@@ -337,15 +317,11 @@
+ WRAPPER_GENERATOR_CLASS=$(WRAPPER_GENERATOR_TEMPDIR)/WrapperGenerator.class 
+ XLIBTYPES=$(PLATFORM_SRC)/classes/sun/awt/X11/generator/xlibtypes.txt
+ 
+-ifndef CROSS_COMPILE_ARCH
+ SIZERS_CC = $(CC)
+-else
+-SIZERS_CC = $(HOST_CC)
+-endif
+ 
+ $(SIZERS): $(SIZERS_C) 
+ 	$(prep-target)
+-	$(SIZERS_CC) $(CFLAGS_$(subst .,,$(suffix $@))) $(CPPFLAGS) -o $@ $(SIZER)$(suffix $@).c
++	$(SIZERS_CC) $(CFLAGS_$(subst .,,$(suffix $@))) $(CPPFLAGS) -static -o $@ $(SIZER)$(suffix $@).c
+ 
+ $(WRAPPER_GENERATOR_CLASS): $(WRAPPER_GENERATOR_JAVA)
+ 	$(prep-target)
+@@ -358,6 +334,16 @@
+ 	    $(SIZER_DIR) $(XLIBTYPES) "sizer" $(subst .,,$(suffix $(basename $@)))
+ 
+ $(SIZES): $(SIZERS)
++ifdef CROSS_COMPILE_ARCH
++	@if [ "$(DOHACK)$@" = "true$(PREDEFINED_SIZES)" ]; then \
++	    $(ECHO) COPYING $(PREDEFINED_SIZES_TMPL) into $@; \
++	    $(CP) $(PREDEFINED_SIZES_TMPL) $@; \
++	    $(CHMOD) +w $@;\
++	else	\
++	    $(ECHO) GENERATING $@; \
++	    $(QEMU) $(WRAPPER_GENERATOR_DIR)/sizer$(suffix $@) > $@; \
++	fi
++else
+ 	@if [ "$(DOHACK)$@" = "true$(PREDEFINED_SIZES)" ]; then \
+ 	    $(ECHO) COPYING $(PREDEFINED_SIZES_TMPL) into $@; \
+ 	    $(CP) $(PREDEFINED_SIZES_TMPL) $@; \
+@@ -366,6 +352,7 @@
+ 	    $(ECHO) GENERATING $@; \
+ 	    $(WRAPPER_GENERATOR_DIR)/sizer$(suffix $@) > $@; \
+ 	fi
++endif
+ 	@if [ "$(DOCOMPARE)$(suffix $@)" = "true.64" ]; then \
+ 	    $(ECHO) COMPARING $@ and $(STORED_SIZES_TMPL_$(PLATFORM)_$(LIBARCH)); \
+ 	    $(DIFF) $@ $(STORED_SIZES_TMPL_$(PLATFORM)_$(LIBARCH)); \
+--- openjdk/jdk/make/common/Defs-linux.gmk
++++ openjdk/jdk/make/common/Defs-linux.gmk
+@@ -162,28 +162,6 @@
+   endif
+ endif
+ 
+-#
+-# Default optimization
+-#
+-
+-ifndef OPTIMIZATION_LEVEL
+-  ifeq ($(PRODUCT), java)
+-    OPTIMIZATION_LEVEL = HIGHER
+-  else
+-    OPTIMIZATION_LEVEL = LOWER
+-  endif
+-endif
+-ifndef FASTDEBUG_OPTIMIZATION_LEVEL
+-  FASTDEBUG_OPTIMIZATION_LEVEL = LOWER
+-endif
+-
+-CC_OPT/NONE     = 
+-CC_OPT/LOWER    = -O2
+-CC_OPT/HIGHER   = -O3
+-CC_OPT/HIGHEST  = -O3
+-
+-CC_OPT          = $(CC_OPT/$(OPTIMIZATION_LEVEL))
+-
+ # For all platforms, do not omit the frame pointer register usage. 
+ #    We need this frame pointer to make it easy to walk the stacks.
+ #    This should be the default on X86, but ia64 and amd64 may not have this
+@@ -191,7 +169,7 @@
+ CFLAGS_REQUIRED_aarch64 += -fno-omit-frame-pointer -fsigned-char -D_LITTLE_ENDIAN
+ CFLAGS_REQUIRED_alpha   += -mieee -D_LITTLE_ENDIAN
+ CFLAGS_REQUIRED_amd64   += -fno-omit-frame-pointer -D_LITTLE_ENDIAN
+-CFLAGS_REQUIRED_arm     += -D_LITTLE_ENDIAN -fsigned-char -D_LITTLE_ENDIAN
++CFLAGS_REQUIRED_arm     += -fno-omit-frame-pointer -fsigned-char -D_LITTLE_ENDIAN
+ CFLAGS_REQUIRED_hppa    +=
+ CFLAGS_REQUIRED_i586    += -fno-omit-frame-pointer -D_LITTLE_ENDIAN
+ CFLAGS_REQUIRED_ia64    += -fno-omit-frame-pointer -D_LITTLE_ENDIAN
+@@ -279,7 +257,7 @@
+   endif
+ endif
+ 
+-CFLAGS_OPT      = $(CC_OPT)
++CFLAGS_OPT      = $(OE_CFLAGS)
+ CFLAGS_DBG      = $(DEBUG_FLAG)
+ CFLAGS_COMMON += $(CFLAGS_REQUIRED)
+ 
+@@ -355,7 +333,7 @@
+ #
+ # -L paths for finding and -ljava
+ #
+-LDFLAGS_OPT     = -Xlinker -O1
++LDFLAGS_OPT     = $(OE_LDFLAGS)
+ LDFLAGS_COMMON += -L$(LIBDIR)/$(LIBARCH)
+ LDFLAGS_COMMON += -Wl,-soname=$(LIB_PREFIX)$(LIBRARY).$(LIBRARY_SUFFIX)
+ 

--- a/recipes-core/openjdk/openjdk-7-55b14/jvm.cfg
+++ b/recipes-core/openjdk/openjdk-7-55b14/jvm.cfg
@@ -1,0 +1,43 @@
+# Copyright 2003 Sun Microsystems, Inc.  All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Sun designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Sun in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+# CA 95054 USA or visit www.sun.com if you need additional information or
+# have any questions.
+#
+# 
+# List of JVMs that can be used as an option to java, javac, etc.
+# Order is important -- first in this list is the default JVM.
+# NOTE that this both this file and its format are UNSUPPORTED and
+# WILL GO AWAY in a future release.
+#
+# You may also select a JVM in an arbitrary location with the
+# "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
+# and may not be available in a future release.
+#
+-server ERROR
+-client IGNORE
+-hotspot ERROR
+-classic WARN
+-native ERROR
+-green ERROR
+-zero ALIASED_TO -server
+-shark ERROR
+-cacao ERROR
+-jamvm ERROR

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -26,7 +26,7 @@ PN = "${JDKPN}-jre"
 PROVIDES += "${JDKPN}"
 
 DEPENDS = " \
-           icedtea6-native zip-native ant-native \
+           icedtea7-native zip-native ant-native \
            zlib \
 	   jpeg libpng giflib \
            gtk+ glib-2.0 \
@@ -101,7 +101,7 @@ EXTRA_OECONF = " \
 	\
         --enable-zero \
 	\
-	--with-jdk-home=${STAGING_LIBDIR_JVM_NATIVE}/icedtea6-native \
+	--with-jdk-home=${STAGING_LIBDIR_JVM_NATIVE}/icedtea7-native \
 	--with-rhino=${STAGING_DATADIR_JAVA}/rhino.jar \
 	\
         --with-openjdk-src-zip=${WORKDIR}/${OPENJDK_FILE} \
@@ -226,6 +226,7 @@ PACKAGES = " \
 FILES_${JDKPN}-dbg = "\
 	${JDK_HOME}/bin/.debug \
 	${JDK_HOME}/lib/.debug \
+	${JDK_HOME}/lib/${JDK_ARCH}/jli/.debug \
 	${JDK_HOME}/jre/bin/.debug \
 	${JDK_HOME}/jre/lib/.debug \
 	${JDK_HOME}/jre/lib/${JDK_ARCH}/.debug \

--- a/recipes-core/openjdk/openjdk-7-release-55b14.inc
+++ b/recipes-core/openjdk/openjdk-7-release-55b14.inc
@@ -1,0 +1,80 @@
+require openjdk-7-common.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
+
+FILESPATH =. "${FILE_DIRNAME}/openjdk-7-55b14:"
+
+# Name of the directory containing the compiled output
+BUILD_DIR = "openjdk.build"
+BUILD_DIR_ECJ = "openjdk.build-ecj"
+
+# Force arm mode for now
+ARM_INSTRUCTION_SET_armv4t = "ARM"
+
+ICEDTEA_URI = "http://icedtea.wildebeest.org/download/source/${ICEDTEA}.tar.gz;name=iced"
+
+ICEDTEA_PREFIX = "icedtea7-forest-2.4"
+ICEDTEA_HG_URL = "http://icedtea.classpath.org/hg/release/${ICEDTEA_PREFIX}"
+
+OPENJDK_FILE = "${OPENJDK_CHANGESET}.tar.bz2"
+OPENJDK_URI = "${ICEDTEA_HG_URL}/archive/${OPENJDK_FILE};name=openjdk;unpack=false"
+
+HOTSPOT_FILE = "${HOTSPOT_CHANGESET}.tar.gz"
+HOTSPOT_URI = "${ICEDTEA_HG_URL}/hotspot/archive/${HOTSPOT_FILE};name=hotspot;unpack=false"
+
+CORBA_FILE = "${CORBA_CHANGESET}.tar.gz"
+CORBA_URI = "${ICEDTEA_HG_URL}/corba/archive/${CORBA_FILE};name=corba;unpack=false"
+
+JAXP_FILE = "${JAXP_CHANGESET}.tar.gz"
+JAXP_URI = "${ICEDTEA_HG_URL}/jaxp/archive/${JAXP_FILE};name=jaxp;unpack=false"
+
+JAXWS_FILE = "${JAXWS_CHANGESET}.tar.gz"
+JAXWS_URI = "${ICEDTEA_HG_URL}/jaxws/archive/${JAXWS_FILE};name=jaxws;unpack=false"
+
+JDK_FILE = "${JDK_CHANGESET}.tar.gz"
+JDK_URI = "${ICEDTEA_HG_URL}/jdk/archive/${JDK_FILE};name=jdk;unpack=false"
+
+LANGTOOLS_FILE = "${LANGTOOLS_CHANGESET}.tar.gz"
+LANGTOOLS_URI = "${ICEDTEA_HG_URL}/langtools/archive/${LANGTOOLS_FILE};name=langtools;unpack=false"
+
+CACAO_VERSION = "e215e36be9fc"
+CACAO_FILE = "${CACAO_VERSION}.tar.gz"
+CACAO_URI = "http://icedtea.wildebeest.org/download/drops/cacao/${CACAO_FILE};name=cacao;unpack=false"
+SRC_URI[cacao.md5sum] = "79f95f0aea4ba04cf2f1a8632ac66d14"
+SRC_URI[cacao.sha256sum] = "4966514c72ee7ed108b882d9b6e65c3adf8a8f9c2dccb029f971b3c8cb4870ab"
+
+JAMVM_VERSION = "ac22c9948434e528ece451642b4ebde40953ee7e"
+JAMVM_FILE = "jamvm-${JAMVM_VERSION}.tar.gz"
+JAMVM_URI = "http://icedtea.wildebeest.org/download/drops/jamvm/${JAMVM_FILE};name=jamvm;unpack=false"
+SRC_URI[jamvm.md5sum] = "3a67d0f3471bd2d5b2446d91bfa73f73"
+SRC_URI[jamvm.sha256sum] = "4662da1fe3e0e11d8fa685c7f2fc748576b9f3d3e37dc56b798dd6a5bd6b61e7"
+
+# FIXME: we shouldn't override the QA!
+do_package_qa() {
+	pwd
+}
+
+# Allow overriding this separately
+OEPATCHES = "\
+	file://0000_build_hacks.patch \
+	"
+
+# Allow overriding this separately
+ICEDTEAPATCHES = "\
+	file://0001_hotspot-fix-zeroshark-build.patch;apply=no \
+	file://0002_jdk-fix-nio-gensor-genuc-gensc-build.patch;apply=no \
+	file://0003_hotspot-div-crosscompile-fixes.patch;apply=no \
+	file://0004_corba-fix-crosscompile.patch;apply=no \
+	file://0005_jdk-div-crosscompile-fixes.patch;apply=no \
+	"
+
+# Allow overriding this separately
+DISTRIBUTION_PATCHES = "\
+	../0001_hotspot-fix-zeroshark-build.patch \
+	../0002_jdk-fix-nio-gensor-genuc-gensc-build.patch \
+	../0003_hotspot-div-crosscompile-fixes.patch \
+	../0004_corba-fix-crosscompile.patch \
+	../0005_jdk-div-crosscompile-fixes.patch \
+	"
+
+export DISTRIBUTION_PATCHES

--- a/recipes-core/openjdk/openjdk-7_55b14-2.4.7.bb
+++ b/recipes-core/openjdk/openjdk-7_55b14-2.4.7.bb
@@ -1,0 +1,35 @@
+require openjdk-7-release-55b14.inc
+
+PR = "${INC_PR}.0"
+
+SRC_URI[iced.md5sum] = "3e2c46f5b0bce2821af79bb286b451b8"
+SRC_URI[iced.sha256sum] = "754350cbd704b22b7ba3d14c8283eb2d896d137824f95a9e6a2b34678658ade1"
+
+CORBA_CHANGESET = "e6ad5b912691"
+SRC_URI[corba.md5sum] = "0a8f2235307b68553865ac38192690c7"
+SRC_URI[corba.sha256sum] = "cc37272df260d08207c84763d4c39d7807728ba2d5908276b9bc63e925e70674"
+
+JAXP_CHANGESET = "94b7e8e0d96f"
+SRC_URI[jaxp.md5sum] = "ba7a21a3ef2ce5d0d47c7015e43c5dcf"
+SRC_URI[jaxp.sha256sum] = "3515cd105c29563bf78432576e658005386f45d7c3b2b7eac7af86cf196aaaea"
+
+JAXWS_CHANGESET = "bd9a50a78d04"
+SRC_URI[jaxws.md5sum] = "9ef2ea5b1e87777c75a72e1dca6fab1d"
+SRC_URI[jaxws.sha256sum] = "3e107628080d84a80a78ef0ef9dc3664989291dd17c8bacf031d59fba7bd7f4d"
+
+JDK_CHANGESET = "9448fff93286"
+SRC_URI[jdk.md5sum] = "cea74e96852bf017f73222fa7045daee"
+SRC_URI[jdk.sha256sum] = "9222e5317264f20d4a0b8170b4c4d02459cda98333c18e3a75064e7856ff58be"
+
+LANGTOOLS_CHANGESET = "8c26a3c39128"
+SRC_URI[langtools.md5sum] = "449cec19b80ab70935d02d03e3cbc568"
+SRC_URI[langtools.sha256sum] = "5af29e32344e2f2fc0beb31f91b8312f2a0d6d02c53b4cb700ee2e27bcf1043b"
+
+OPENJDK_CHANGESET = "13970e76b784"
+SRC_URI[openjdk.md5sum] = "89bd6af727aa161170b560506843a694"
+SRC_URI[openjdk.sha256sum] = "750383a5e6a09f745d3695d0bc90182027153acfd9f196b9973d4e0f51e38b71"
+
+# located in hotspot.map
+HOTSPOT_CHANGESET = "69b542696e5b"
+SRC_URI[hotspot.md5sum] = "0381ef3920f1ff5c8ac6c8860974d8cc"
+SRC_URI[hotspot.sha256sum] = "e3bbed298ed7c77169fdfddc47cdb85c62ef2e5e7ea04ca28aa8779861efca65"


### PR DESCRIPTION
Hi,
I've added recipes for IcedTea 2.4.7 using OpenJDK 7u55 due to the fact it contains lots of security fixes.

On my test platform (ARMv7) everything is working well:
```
localhost:~# java -version
java version "1.7.0_55"
OpenJDK Runtime Environment (IcedTea 2.4.7) (55b14-2.4.7)
OpenJDK Zero VM (build 24.51-b03, mixed mode)
```

Maybe some testing on other platforms to make sure it also works there would be a good idea.

So I'm awaiting your comments, test results and/or merge ;-)

regards,
Richard