### PR TITLE
jamvm: port to new update-alternatives

### DIFF
--- a/recipes-core/jamvm/jamvm.inc
+++ b/recipes-core/jamvm/jamvm.inc
@@ -54,8 +54,8 @@ INSANE_SKIP_${PN} = "dev-so"
 
 FILES_${PN} += "${libdir}/jamvm/lib*.so"
 
-ALTERNATIVE_NAME = "java"
-ALTERNATIVE_PATH = "${bindir}/jamvm"
+ALTERNATIVE_${PN} = "java"
+ALTERNATIVE_TARGET = "${bindir}/jamvm"
 ALTERNATIVE_PRIORITY = "4"
 # shared state for jamvm-native does not work
 # since the paths are hardcoded


### PR DESCRIPTION
Hi,

the jamvm recipe did not create a link to /bin/java because the API of the update-alternatives class changed in yocto Daisy.

I'm not 100% sure if I used it correctly but it works for me.

This issue is also present in other recipes. But I got no time to fix it.

Greetings
Merten
