### PR TITLE
openjdk-7: inherit pkgconfig

### DIFF
--- a/recipes-core/openjdk/openjdk-common.inc
+++ b/recipes-core/openjdk/openjdk-common.inc
@@ -17,7 +17,7 @@ DEPENDS_append_libc-uclibc = " virtual/libiconv "
 # because structure sizes and/or alignment may differ.
 DEPENDS_append = " qemu-native "
 
-inherit java autotools gettext qemu
+inherit java pkgconfig autotools gettext qemu
 
 # OpenJDK uses slightly different names for certain arches. We need to know
 #	this to create some files which are expected by the build.


### PR DESCRIPTION
Building OpenJDK-7 in Yocto 1.7 (Dizzy) quits with errors as follows. Inheriting pkgconfig fixes this problem.
.../configure: line 8645: syntax error near unexpected token `NSS,'
.../configure: line 8645:`PKG_CHECK_MODULES(NSS, nss, NSS_FOUND=yes, NSS_FOUND=no)'
