### PR TITLE
openjdk: fix do_install for out of source builds

### DIFF
--- a/recipes-core/openjdk/openjdk-6-common.inc
+++ b/recipes-core/openjdk/openjdk-6-common.inc
@@ -234,7 +234,7 @@ do_compile() {
 
 do_install() {
 	install -d ${D}${libdir_jvm}
-	cp -R ${WORKDIR}/build/${BUILD_DIR}/j2sdk-image ${D}${JDK_HOME}
+	cp -R ${B}/${BUILD_DIR}/j2sdk-image ${D}${JDK_HOME}
 
 	chmod u+rw -R ${D}${JDK_HOME}
 

--- a/recipes-core/openjdk/openjdk-7-common.inc
+++ b/recipes-core/openjdk/openjdk-7-common.inc
@@ -172,7 +172,7 @@ do_compile() {
 
 do_install() {
 	install -d ${D}${libdir_jvm}
-	cp -R ${WORKDIR}/build/${BUILD_DIR}/j2sdk-image ${D}${JDK_HOME}
+	cp -R ${B}/${BUILD_DIR}/j2sdk-image ${D}${JDK_HOME}
 
 	chmod u+rw -R ${D}${JDK_HOME}
 


### PR DESCRIPTION
Hi

Between daisy and dizzy the directory of the build output changed from ${S}/build to ${WORKDIR}/build/
Commit d2b75b615e4612f9fa05950c1d76d4a719e573d4 changes the install task to use the new definition making meta-java work on dizzy but no longer on older versions.
The variable B contains the relevant path already so using ${B} for either ${S}/build or ${WORKDIR}/build keeps compatibility with new and old.

Regards
Max
